### PR TITLE
Fix analyzer options and string conversion

### DIFF
--- a/src/main/java/amigahunk/AmigaHunkAnalyzer.java
+++ b/src/main/java/amigahunk/AmigaHunkAnalyzer.java
@@ -94,9 +94,10 @@ public class AmigaHunkAnalyzer extends AbstractAnalyzer {
 			return;
 		}
 
-		String[] libsList = funcsList.getLibsList(filter);
+		String[] libsList = funcsList.getLibsList(null);
 		for (String lib : libsList) {
-			options.registerOption(lib.replace(FdParser.LIB_FD_EXT, "").toUpperCase(), true, null, String.format("Analyze calls from %s", lib));
+			boolean defaultValue = filter.contains(lib);
+			options.registerOption(lib.replace(FdParser.LIB_FD_EXT, "").toUpperCase(), defaultValue, null, String.format("Analyze calls from %s", lib));
 		}
 	}
 	

--- a/src/main/java/hunk/HunkIndexBlock.java
+++ b/src/main/java/hunk/HunkIndexBlock.java
@@ -21,12 +21,6 @@ public class HunkIndexBlock extends HunkBlock {
 		calcHunkSize(reader);
 	}
 	
-	private static String getStringFromOffset(byte[] array, int offset) {
-		int i;
-		for (i = offset; i < array.length && array[i] != 0; i++) { }
-		return new String(array, offset, i - offset);
-	}
-
 	@Override
 	void parse(BinaryReader reader, boolean isExecutable) throws HunkParseError {
 		try {


### PR DESCRIPTION
This fixes the Analyzer option registration problem with the current development version of Ghidra (only DOS and EXEC are included in the list).

While I was working on this, I also changed the conversion from bytes to String. It now uses ISO-8859-1 instead of the platform's default character set. This also removes the dependency to com.google.guava package (now it would be possible to use classpath/project files without absolute paths in an Eclipse workspace where the Ghidra project is included).